### PR TITLE
fix date handling by using date-fns

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "class-validator": "^0.13.1",
         "cors": "^2.8.5",
         "crypto-js": "^4.0.0",
+        "date-fns": "^2.20.1",
         "dotenv": "^8.2.0",
         "express": "^4.17.1",
         "express-rate-limit": "^5.2.5",

--- a/src/models/Election/ElectionEntity.ts
+++ b/src/models/Election/ElectionEntity.ts
@@ -46,7 +46,7 @@ export class Election implements IElection {
     @Column({ type: String, nullable: true })
     image!: string
 
-    @IsEarlierThan('closeDate', { message: 'Opening date must be before closing date' })
+    @IsEarlierThan('closeDate', { message: 'Opening date must be before closing date', always: true })
     @IsOptional({ always: true })
     @MinDate(new Date(), {
         groups: ['creation'],

--- a/src/models/constraints/isEarlierThan.ts
+++ b/src/models/constraints/isEarlierThan.ts
@@ -1,21 +1,28 @@
-import { registerDecorator, ValidationOptions, ValidationArguments } from 'class-validator'
+import { registerDecorator, ValidationArguments, ValidationOptions } from 'class-validator'
+import { compareDesc } from 'date-fns'
 
 export function IsEarlierThan(property: string, validationOptions?: ValidationOptions) {
-  return function (object: Object, propertyName: string) {
-    registerDecorator({
-      name: 'isEarlierThan',
-      target: object.constructor,
-      propertyName: propertyName,
-      constraints: [property],
-      options: validationOptions,
-      validator: {
-        validate(value: any, args: ValidationArguments) {
-          const [relatedPropertyName] = args.constraints
-          const relatedValue = (args.object as any)[relatedPropertyName]
-          if (!value || !relatedValue) return true
-          return value <= relatedValue // you can return a Promise<boolean> here as well, if you want to make async validation
-        }
-      }
-    })
-  }
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    return function (object: Object, propertyName: string) {
+        registerDecorator({
+            name: 'isEarlierThan',
+            target: object.constructor,
+            propertyName: propertyName,
+            constraints: [property],
+            options: validationOptions,
+            validator: {
+                validate(value: any, args: ValidationArguments) {
+                    const [relatedPropertyName] = args.constraints
+                    const relatedValue = (args.object as any)[relatedPropertyName]
+
+                    if (!value || !relatedValue) return true
+
+                    // Compare the two dates and return -1 if the first date is after the second
+                    const compared = compareDesc(value, relatedValue)
+
+                    return compared !== -1 // you can return a Promise<boolean> here as well, if you want to make async validation
+                }
+            }
+        })
+    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1887,6 +1887,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns@^2.20.1:
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.20.1.tgz#7e60b7035284a5f83e37500376e738d9f49ecfd3"
+  integrity sha512-8P5M8Kxbnovd0zfvOs7ipkiVJ3/zZQ0F/nrBW4x5E+I0uAZVZ80h6CKd24fSXQ5TLK5hXMtI4yb2O5rEZdUt2A==
+
 dateformat@~1.0.4-1.2.3:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-1.0.12.tgz#9f124b67594c937ff706932e4a642cca8dbbfee9"


### PR DESCRIPTION
The backend now supports passing dates as a part of the create election request. It handles the open and closing date properly to check if the dates are valid opening and closing dates.

Tightly coupled with the frontend pr: ref anovote/frontend#193